### PR TITLE
Dev (#142)

### DIFF
--- a/src/plugins/onMessage/help.php
+++ b/src/plugins/onMessage/help.php
@@ -88,7 +88,7 @@ class help
                 $this->logger->addInfo("Help: Sending help info to {$user}");
             } else {
                 foreach ($plugins as $plugin) {
-                    if ($messageString === $plugin->information()['name']) {
+                    if (strtolower($messageString) === strtolower($plugin->information()['name'])) {
                         $this->message->reply($plugin->information()['information']);
                     }
                 }


### PR DESCRIPTION
* catch up dev (#141)

* Fix citidel fuel notification

You can't use hard coded indexes for $notificationString because the indexes change depending on how many service modules are installed.

* Update README.md

* remove case sensitivity for help