### PR TITLE
Dev (#153)

### DIFF
--- a/config/config.new.php
+++ b/config/config.new.php
@@ -163,8 +163,8 @@ $config['plugins'] = array(
             )
         ),
         'standings' => array(
-            'enabled' => 'false',
-            'apiKey' => 'user1',
+            'enabled' => 'false',//set to true if you want to allow people to auth based off of corp/alliance standings
+            'apiKey' => 'user1',//enter the KEYID for whatever above api you'd like to base standings off of
             'plus10Role' => '',
             'plus5Role' => '',
             'neutralRole' => '',

--- a/src/plugins/onTick/authCheck.php
+++ b/src/plugins/onTick/authCheck.php
@@ -446,7 +446,7 @@ class authCheck
     private function standingsUpdate()
     {
         foreach ($this->apiKey as $apiKey) {
-            if ($apiKey['keyID'] === $this->config['plugins']['auth']['standings']['apiKey']) {
+            if ((string)$apiKey['keyID'] === (string)$this->config['plugins']['auth']['standings']['apiKey']) {
                 $url = "https://api.eveonline.com/char/ContactList.xml.aspx?keyID={$apiKey['keyID']}&vCode={$apiKey['vCode']}&characterID={$apiKey['characterID']}";
                 $xml = makeApiRequest($url);
                 if (empty($xml)) {
@@ -455,7 +455,9 @@ class authCheck
                 foreach ($xml->result->rowset as $contactType) {
                     if ((string)$contactType->attributes()->name === 'corporateContactList' || 'allianceContactList') {
                         foreach ($contactType->row as $contact) {
-                            addContactInfo($contact['contactID'], $contact['contactName'], $contact['standing']);
+                            if (null !== $contact['contactID'] && $contact['contactName'] && $contact['standing']) {
+                                addContactInfo($contact['contactID'], $contact['contactName'], $contact['standing']);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
* catch up dev (#141)

* Fix citidel fuel notification

You can't use hard coded indexes for $notificationString because the indexes change depending on how many service modules are installed.

* Update README.md

* remove case sensitivity for help

* tweak esi checks

* fix siphon detection (Finally!)

* close #136

* close #148

* initial standings based auth commit

* standings based auth

* standings based auth fix