### PR TITLE
Check if a killmail is available and not null

### DIFF
--- a/src/plugins/onTick/getKillmailsRedis.php
+++ b/src/plugins/onTick/getKillmailsRedis.php
@@ -85,7 +85,10 @@ class getKillmailsRedis
             $kill = zKillRedis();
             $i++;
 
-            //Check if mail is null
+            //Check if there is a killmail available and mail is not null
+            if(!is_array($kill)){
+                break;
+            }
             if (!array_key_exists('killID', $kill)) {
                 break;
             }


### PR DESCRIPTION
If there isn't a killmail available on the RedisQ, zKill will return null (or not anything at all) and Dramiel will report
PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /home/user/Dramiel/src/plugin/onTick/getKillmailsRedis.php on line 89